### PR TITLE
english: simplify the filter

### DIFF
--- a/english.lua
+++ b/english.lua
@@ -1,43 +1,13 @@
-local lang = 'english'
-
-local before = pandoc.RawInline(
-  'tex', '\\begin{otherlanguage}{' .. lang .. '}')
-local after = pandoc.RawInline(
-  'tex', '\\end{otherlanguage}')
-
-local meta = {}
+local lang = 'en'
 
 return {
   {
-    Meta = function (el)
-      meta = el
-      meta['babel-otherlangs'] = lang
-      meta['polyglossia-otherlangs'] = {name = lang}
-      return {}
-    end,
-  }, {
-    Code = function(code)
-      return {before, code, after}
+    Code = function(el)
+      return pandoc.Span(el, pandoc.Attr("", {}, {lang = lang}))
     end,
 
-    CodeBlock = function(code_block)
-      return {
-        pandoc.Para({before}),
-        code_block,
-        pandoc.Para({after})
-      }
-    end,
-
-    RawBlock = function(raw_block)
-      return {
-        pandoc.Para({before}),
-        raw_block,
-        pandoc.Para({after})
-      }
-    end,
-  }, {
-    Meta = function (_)
-      return meta
+    CodeBlock = function(el)
+      return pandoc.Div(el, pandoc.Attr("", {}, {lang = lang}))
     end,
   }
 }

--- a/rapport.md
+++ b/rapport.md
@@ -462,33 +462,16 @@ $ pandoc rapport.md \
 Sans ceci, tous les exemples contenant ces éléments de ponctuation seraient cassés. C'est un usage très avancé, que les plus informaticiens d'entre vous sauront dompter.
 
 ```{#lst:english .lua .numberLines caption="english.lua"}
-local lang = 'english'
-
-local before = pandoc.RawInline(
-  'tex', '\\begin{otherlanguage}{' .. lang .. '}')
-local after = pandoc.RawInline(
-  'tex', '\\end{otherlanguage}')
+local lang = 'en'
 
 return {
   {
-    Code = function(code)
-      return {before, code, after}
+    Code = function(el)
+      return pandoc.Span(el, pandoc.Attr("", {}, {lang = lang}))
     end,
 
-    CodeBlock = function(code_block)
-      return {
-        pandoc.Para({before}),
-        code_block,
-        pandoc.Para({after})
-      }
-    end,
-
-    RawBlock = function(raw_block)
-      return {
-        pandoc.Para({before}),
-        raw_block,
-        pandoc.Para({after})
-      }
+    CodeBlock = function(el)
+      return pandoc.Div(el, pandoc.Attr("", {}, {lang = lang}))
     end,
   }
 }


### PR DESCRIPTION
Application du nouveau filtre, au combien plus simple. Il n'est pas possible d'avoir le même comportement pour le `RawBlock` car ce dernier est utilisé pour la partie `header-includes` qui permet d'injecter du LaTeX sauvagement.

https://github.com/pandoc/lua-filters/pull/36